### PR TITLE
Fix file entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "require": "./js/src/cjs/index.js"
   },
   "files": [
-    "js/src/*.mjs"
+    "js/src/**/*.js"
   ],
   "scripts": {
     "test": "jest --silent",


### PR DESCRIPTION
Closes #48.

`"files"` was not set to the correct glob. Now everything should be correctly packed.