### PR TITLE
Rollback GitHub runner Python OS to Ubuntu 20.04

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -2,14 +2,14 @@ name: Automated Python tests
 on: [pull_request]
 jobs:
   Unit-Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update pip
@@ -21,14 +21,14 @@ jobs:
       - name: Test with pytest
         run: poetry run pytest --junitxml=artifacts/python/junit.xml
   Code-Coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - name: Update pip

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update pip
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Update pip


### PR DESCRIPTION
When this repo was created, 20.04 was the latest Ubuntu version.

Per the [versions-manifest.json](https://github.com/actions/python-versions/blob/af22c2b8e41acf6dc7c64030339622962820df9e/versions-manifest.json) file for actions/python-versions (as of today, 23.12.11), there's no support for Python 3.6 with Ubuntu 22.04.